### PR TITLE
Allow including indices when hashing molecules

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,21 +260,29 @@ print(space)
 
 ### Hashing and Identity
 
-Individual molecules in a chemical space are hashed by their InChI Keys only.   
-Indices and scores **do not** affect the hashing process.
+Individual molecules in a chemical space are hashed by their InChI Keys only (by default), or by InChI Keys and index.
+Scores **do not** affect the hashing process.
 
 ```python
-from rdkit import Chem
-from rdkit.Chem import inchi
+from chemicalspace import ChemicalSpace
 
-mol = Chem.MolFromSmiles("c1ccccc1")
-inchi_key = inchi.MolToInchiKey(mol)
+smiles = ('CCO', 'CCN', 'CCl')
+indices = ("mol1", "mol2", "mol3")
 
-print(inchi_key)
+# Two spaces with the same molecules, and indices
+# But one space includes the indices in the hashing process
+space_indices = ChemicalSpace(mols=smiles, indices=indices, hash_indices=True)
+space_no_indices = ChemicalSpace(mols=smiles, indices=indices, hash_indices=False)
+
+print(space_indices == space_indices)
+print(space_indices == space_no_indices)
+print(space_no_indices == space_no_indices)
 ```
 
 ```text
-UHOVQNZJYSORNB-UHFFFAOYSA-N
+True
+False
+True
 ```
 
 `ChemicalSpace` objects are hashed by their molecular hashes, in an **order-independent** manner.
@@ -290,10 +298,6 @@ inchi_key = inchi.MolToInchiKey(mol)
 space = ChemicalSpace(mols=(mol,))
 
 assert hash(space) == hash(frozenset((inchi_key,)))
-```
-
-```text
-True
 ```
 
 The identity of a `ChemicalSpace` is evaluated on its hashed representation.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -194,6 +194,18 @@ def test_copy(space: ChemicalSpaceBaseLayer) -> None:
     assert id(space.mols[0]) != id(space_deep.mols[0])
 
 
+@pytest.mark.parametrize("use_indices", [True, False])
+def test_hashing(use_indices: bool, input_file: str = INPUT_SMI_FILES[0]) -> None:
+    space = ChemicalSpaceBaseLayer.from_smi(input_file, hash_indices=use_indices)
+    space_noindices = ChemicalSpaceBaseLayer.from_smi(input_file, hash_indices=False)
+
+    assert space == space
+    if use_indices:
+        assert space != space_noindices
+    else:
+        assert space == space_noindices
+
+
 def test_deduplicate(space: ChemicalSpaceBaseLayer) -> None:
     space_twice = space + space
 


### PR DESCRIPTION
Resolves #11 

Now `ChemicalSpaces` can be hashed by the inchi keys of their molecules only (by default), or also by the index as well