### PR TITLE
Return a `ChemicalSpace` from `__getitem__`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   - repo: https://github.com/psf/black
     rev: 24.4.2
     hooks:
-      - id: black
+      - id: black-jupyter
         name: black
         language_version: python3.11.9
         types_or:

--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ print(space)
 
 ### Indexing, Slicing and Masking
 
+Indexing, slicing and masking a `ChemicalSpace` object returns a new `ChemicalSpace` object.
+
 #### Indexing
 
-Single indexing and builtin slicing returns a tuple of the molecule(s), index(es) and score(s).
 
 ```python
 from chemicalspace import ChemicalSpace
@@ -81,8 +82,23 @@ print(space[0])
 ```
 
 ```text
-(<rdkit.Chem.rdchem.Mol object at 0x76dd0ded8900>, 'CHEMBL2205617', None)
+<ChemicalSpace: 1 molecules | 1 indices | No scores>
 ```
+
+```python
+from chemicalspace import ChemicalSpace
+
+space = ChemicalSpace.from_smi("tests/data/inputs1.smi")
+idx = [1, 2, 4]
+
+print(space[idx])
+```
+
+```text
+<ChemicalSpace: 3 molecules | 3 indices | No scores>
+```
+
+#### Slicing
 
 ```python
 from chemicalspace import ChemicalSpace
@@ -93,43 +109,18 @@ print(space[:2])
 ```
 
 ```text
-(
-  (<rdkit.Chem.rdchem.Mol object at 0x76dd0ded8dd0>,
-   <rdkit.Chem.rdchem.Mol object at 0x76dd0ded8e40>),
-  ('CHEMBL2205617', 'CHEMBL3322349'),
-  None
-)
-```
-
-#### Slicing
-
-Slicing with `.slice` returns a new `ChemicalSpace` object.
-
-```python
-from chemicalspace import ChemicalSpace
-
-space = ChemicalSpace.from_smi("tests/data/inputs1.smi")
-space_sliced = space.slice(start=0, stop=6, step=2)
-
-print(space_sliced)
-```
-
-```text
-<ChemicalSpace: 3 molecules | 3 indices | No scores>
+<ChemicalSpace: 2 molecules | 2 indices | No scores>
 ```
 
 #### Masking
-
-Masking with `.mask` returns a new `ChemicalSpace` object.
 
 ```python
 from chemicalspace import ChemicalSpace
 
 space = ChemicalSpace.from_smi("tests/data/inputs1.smi")
 mask = [True, False, True, False, True, False, True, False, True, False]
-space_masked = space.mask(mask)
 
-print(space_masked)
+print(space[mask])
 ```
 
 ```text
@@ -191,7 +182,7 @@ inherit the respective features.
 from chemicalspace import ChemicalSpace
 
 space = ChemicalSpace.from_smi("tests/data/inputs1.smi")
-space_slice = space.slice(start=0, stop=6, step=2)
+space_slice = space[0:6:2]
 
 # Custom ECFP4 features
 print(space.features.shape)
@@ -211,7 +202,7 @@ from chemicalspace import ChemicalSpace
 from chemicalspace.layers.utils import maccs_featurizer
 
 space = ChemicalSpace.from_smi("tests/data/inputs1.smi", featurizer=maccs_featurizer)
-space_slice = space.slice(start=0, stop=6, step=2)
+space_slice = space[0:6:2]
 
 # Custom ECFP4 features
 print(space.features.shape)

--- a/chemicalspace/layers/acquisition.py
+++ b/chemicalspace/layers/acquisition.py
@@ -234,4 +234,4 @@ class ChemicalSpaceAcquisitionLayer(ChemicalSpaceBaseLayer):
         mask = np.zeros(len(self.features), dtype=bool)
         mask[pick_idx] = True
 
-        return self.mask(mask)
+        return self[mask]

--- a/chemicalspace/layers/clustering.py
+++ b/chemicalspace/layers/clustering.py
@@ -154,7 +154,7 @@ class ChemicalSpaceClusteringLayer(ChemicalSpaceBaseLayer):
 
         for i in range(n):
             mask = np.array(labels == i)
-            yield self.mask(mask)
+            yield self[mask]
 
     def ksplits(
         self,

--- a/chemicalspace/layers/neigbors.py
+++ b/chemicalspace/layers/neigbors.py
@@ -98,4 +98,4 @@ class ChemicalSpaceNeighborsLayer(ChemicalSpaceBaseLayer):
         idx = self.find_overlap(other, radius, min_neighbors=min_neighbors)
         mask = np.ones(len(self.features), dtype=bool)
         mask[idx] = False
-        return self.mask(mask)
+        return self[mask]

--- a/notebooks/00-qsar-modelling.ipynb
+++ b/notebooks/00-qsar-modelling.ipynb
@@ -45,8 +45,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[11:45:43] Warning: ambiguous stereochemistry - linear bond arrangement - at atom 3 ignored\n",
-      "[11:45:43] Warning: ambiguous stereochemistry - linear bond arrangement - at atom 10 ignored\n"
+      "[12:42:50] Warning: ambiguous stereochemistry - linear bond arrangement - at atom 3 ignored\n",
+      "[12:42:50] Warning: ambiguous stereochemistry - linear bond arrangement - at atom 10 ignored\n"
      ]
     },
     {
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -173,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -184,7 +184,7 @@
        "<PIL.PngImagePlugin.PngImageFile image mode=RGB size=300x300>"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -213,7 +213,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -236,26 +236,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<style>#sk-container-id-6 {color: black;}#sk-container-id-6 pre{padding: 0;}#sk-container-id-6 div.sk-toggleable {background-color: white;}#sk-container-id-6 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-6 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-6 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-6 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-6 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-6 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-6 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-6 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-6 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-6 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-6 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-6 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-6 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-6 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-6 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-6 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-6 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-6 div.sk-item {position: relative;z-index: 1;}#sk-container-id-6 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-6 div.sk-item::before, #sk-container-id-6 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-6 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-6 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-6 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-6 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-6 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-6 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-6 div.sk-label-container {text-align: center;}#sk-container-id-6 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-6 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-6\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>RandomForestClassifier(random_state=42)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-6\" type=\"checkbox\" checked><label for=\"sk-estimator-id-6\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">RandomForestClassifier</label><div class=\"sk-toggleable__content\"><pre>RandomForestClassifier(random_state=42)</pre></div></div></div></div></div>"
+       "<style>#sk-container-id-1 {color: black;}#sk-container-id-1 pre{padding: 0;}#sk-container-id-1 div.sk-toggleable {background-color: white;}#sk-container-id-1 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-1 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-1 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-1 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-1 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-1 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-1 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-1 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-1 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-1 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-1 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-1 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-1 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-1 div.sk-item {position: relative;z-index: 1;}#sk-container-id-1 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-1 div.sk-item::before, #sk-container-id-1 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-1 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-1 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-1 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-1 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-1 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-1 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-1 div.sk-label-container {text-align: center;}#sk-container-id-1 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-1 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-1\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>RandomForestClassifier(random_state=42)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-1\" type=\"checkbox\" checked><label for=\"sk-estimator-id-1\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">RandomForestClassifier</label><div class=\"sk-toggleable__content\"><pre>RandomForestClassifier(random_state=42)</pre></div></div></div></div></div>"
       ],
       "text/plain": [
        "RandomForestClassifier(random_state=42)"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "space_train = space.mask(mask)\n",
-    "space_holdout = space.mask(~mask)\n",
+    "space_train = space[mask]\n",
+    "space_holdout = space[~mask]\n",
     "\n",
     "model = RandomForestClassifier(random_state=42)\n",
     "model.fit(space_train.features, space_train.scores)"
@@ -270,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -23,7 +23,7 @@ def test_attributes(space):
     assert space._features is None
 
     # Base
-    assert hasattr(space, "mask")
+    assert hasattr(space, "chunks")
     # Clustering
     assert hasattr(space, "cluster")
     # Neighbors


### PR DESCRIPTION
Return a `ChemicalSpace` object (or respective later) from `__getitem__` instead of a tuple of molecules, indices and scores.

Resolves #22 